### PR TITLE
Fix config file handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,34 @@ Follow the project’s coding guidelines:
 * **Assets**: Embed large assets in separate TUs
 * **Global State**: Avoid globals, pass context structs
 
-For more details, see the [Code Standards section in README](README.md#code-standards).
+### Key practices
+
+* **Modern Compiler Features:** Requires C23/C++23 (`#embed`)
+* **Thread Safety:** Thread-safe logging, mutexes, LockGuard, and atomic operations (`atomic_store/load`)
+* **Memory & Resource Management:**
+    * Prefer stack over heap; use heap only when required for mutexes or dynamic arrays
+    * RAII for resources: Mutex, MMap, Buffers, FileDescriptors
+    * Move semantics for cleanup reduction
+* **Code Modernization:**
+    * Use `ref&` instead of raw pointers (not-nullable)
+    * Use `nullptr` instead of `NULL`
+    * Replace `#define` with `constexpr` where possible
+    * Use `enum class` and default/brace initialization
+* **C++ Usage Restrictions:**
+    * _Almost_ NO STL (only `<type_traits>` used)
+        * Try to avoid using STL, keep core functions coherent with [upstream](https://github.com/saatvik333/wayland-bongocat)
+        * Use Linux, Wayland and standard C libs
+    * No classes except for RAII; apply **Rule of Five**
+    * Minimal `template` usage
+* **Asset Management:**
+    * Embed large assets in separate translation units
+    * Access via dedicated functions
+* **Global State:**
+    * Reduce globals, prefer context structs passed as parameters
+* **Threading:**
+    * Allocate memory upfront before starting threads
+    * Prefer `create` functions with RVO instead of `init` with out-parameters
+    * Stop all threads before releasing memory
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -701,32 +701,7 @@ _**Note:** The binary name in AUR is `wpets`, but during development and `make i
 
 The project is gradually migrating to C++ while retaining a C-style foundation for performance and Wayland compatibility.
 
-##### Key practices:
-
-* **Modern Compiler Features:** Requires C23/C++23 (`#embed`)
-* **Thread Safety:** Thread-safe logging, mutexes, LockGuard, and atomic operations (`atomic_store/load`)
-* **Memory & Resource Management:**
-  * Prefer stack over heap; use heap only when required for mutexes or dynamic arrays
-  * RAII for resources: Mutex, MMap, Buffers, FileDescriptors
-  * Move semantics for cleanup reduction
-* **Code Modernization:**
-  * Use `ref&` instead of raw pointers (not-nullable)
-  * Use `nullptr` instead of `NULL`
-  * Replace `#define` with `constexpr` where possible
-  * Use `enum class` and default/brace initialization
-* **C++ Usage Restrictions:**
-  * _Almost_ NO STL (only `<type_traits>` used)
-  * No classes except for RAII; apply **Rule of Five**
-  * Minimal templates
-* **Asset Management:**
-  * Embed large assets in separate translation units
-  * Access via dedicated functions
-* **Global State:**
-  * Reduce globals, prefer context structs passed as parameters
-* **Threading:**
-  * Allocate memory upfront before starting threads
-  * Prefer `create` functions with RVO instead of `init` with out-parameters
-  * Stop all threads before releasing memory
+For more details, see the [Code Standards section in CONTRIBUTING](CONTRIBUTING.md#code-standards).  
 
 The project remains largely C under the hood, using Linux + Wayland libraries, while gradually adopting modern C++ practices for safety and maintainability.
 

--- a/docs/end.base.bongocat.conf.md
+++ b/docs/end.base.bongocat.conf.md
@@ -48,6 +48,12 @@ idle_sleep_timeout=0             # Inactivity timeout before sleep (seconds, 0=o
 enable_debug=0                   # Show debug messages
 ```
 
+# FILES
+
+    ~/.config/bongocat.conf     Default configuration file
+    bongocat.conf               Fallback configuration file in the current directory.
+
+
 # SEE ALSO
 
 `bongocat(1)`, `bongocat-find-devices(1)`

--- a/docs/fragments/options-all.md
+++ b/docs/fragments/options-all.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/docs/fragments/options-dm-classic.md
+++ b/docs/fragments/options-dm-classic.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/docs/fragments/options-dm.md
+++ b/docs/fragments/options-dm.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/docs/fragments/options-ms-agent.md
+++ b/docs/fragments/options-ms-agent.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/docs/fragments/options-pkmn.md
+++ b/docs/fragments/options-pkmn.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/docs/fragments/options.md
+++ b/docs/fragments/options.md
@@ -5,7 +5,7 @@
             Show version information
 
       -c, --config                
-            Specify config file (default: bongocat.conf)
+            Specify config file (default: ~/.config/bongocat.conf)
             Use "-" to read configuration from standard input.
 
       -w, --watch-config          

--- a/scripts/test_bongocat_4.sh
+++ b/scripts/test_bongocat_4.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#make debug
+#PROGRAM="./cmake-build-debug-all-assets-colored-preload/bongocat"
+PROGRAM="./cmake-build-debug/bongocat-all"
+#PROGRAM="./build/bongocat-all"
+
+echo "[TEST] Starting program (without config)..."
+"$PROGRAM" --watch-config --ignore-running &
+PID=$!
+echo "[TEST] Program PID = $PID"
+sleep 5
+
+# --- trap cleanup ---
+cleanup() {
+    echo "[TEST] Cleaning up..."
+    kill -9 "$PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+
+echo "[TEST] Sending SIGUSR2..."
+echo "[INFO] Send SIGUSR2"
+kill -USR2 "$PID"
+sleep 3
+echo "[INFO] Send SIGUSR2"
+kill -USR2 "$PID"
+sleep 5
+echo "[INFO] Spam SIGUSR2"
+kill -USR2 "$PID"
+kill -USR2 "$PID"
+kill -USR2 "$PID"
+kill -USR2 "$PID"
+sleep 7
+
+
+# --- verify running ---
+if kill -0 "$PID" 2>/dev/null; then
+    echo "[PASS] Process $PID still running!"
+else
+    echo "[FAIL] Process terminated"
+    exit 1
+fi
+
+# --- send SIGTERM ---
+echo "[TEST] Sending SIGTERM..."
+kill -TERM "$PID"
+sleep 10
+echo "[INFO] Wait for TERM"
+# wait up to 5 seconds
+for i in {1..5}; do
+    if ! kill -0 "$PID" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# --- verify not running ---
+if kill -0 "$PID" 2>/dev/null; then
+    echo "[FAIL] Process $PID still running!"
+    kill -9 "$PID" 2>/dev/null
+    exit 1
+else
+    echo "[PASS] Process terminated successfully"
+fi

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -997,6 +997,8 @@ namespace bongocat::config {
     // =============================================================================
 
     created_result_t<config_t> load(const char *config_file_path, load_config_overwrite_parameters_t overwrite_parameters) {
+        BONGOCAT_CHECK_NULL(config_file_path, bongocat_error_t::BONGOCAT_ERROR_INVALID_PARAM);
+
         config_t ret;
         set_defaults(ret);
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -17,8 +17,7 @@
 #include <sys/signalfd.h>
 #include <libgen.h>
 #include <cerrno>
-#include <format>
-#include <string>
+#include <unistd.h>
 
 #include "image_loader/load_images.h"
 
@@ -63,6 +62,7 @@ namespace bongocat {
         platform::Mutex sync_configs;
 
         char* pid_filename{nullptr};
+        char* default_config_filename{nullptr};
 
         main_context_t() = default;
         ~main_context_t() {
@@ -128,6 +128,9 @@ namespace bongocat {
 
         if (context.pid_filename) ::free(context.pid_filename);
         context.pid_filename = nullptr;
+
+        if (context.default_config_filename) ::free(context.pid_filename);
+        context.default_config_filename = nullptr;
     }
 
     inline main_context_t& get_main_context() {
@@ -166,6 +169,8 @@ namespace bongocat {
     inline static constexpr auto PID_FILE_WITH_SUFFIX_TEMPLATE = "/tmp/bongocat-%s.pid";
     inline static constexpr auto PID_FILE_WITH_SUFFIX_MULTI_TEMPLATE = "/tmp/bongocat-%s.%d.pid";
     inline static constexpr auto PID_FILE_WITH_SUFFIX_NR_TEMPLATE = "/tmp/bongocat-%" PRId64 ".pid";
+
+    inline static constexpr auto DEFAULT_CONF_FILENAME = "bongocat.conf";
 
     static platform::FileDescriptor process_create_pid_file(const char *pid_filename) {
         platform::FileDescriptor fd = platform::FileDescriptor(open(pid_filename, O_CREAT | O_WRONLY | O_TRUNC, 0644));
@@ -480,12 +485,40 @@ namespace bongocat {
         return error;
     }
 
-    static std::string default_config_file_path() {
-        const std::string config_file_name{"bongocat.conf"};
-        if (const auto xdg_config_path = std::getenv("XDG_CONFIG_HOME"); xdg_config_path != nullptr) {
-            return std::format("{}/{}", xdg_config_path, config_file_name);
+    static char *default_config_file_path() {
+        const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+        const char *home = getenv("HOME");
+
+        if (xdg_config_home != nullptr) {
+            size_t len = strlen(xdg_config_home) + 1 + strlen(DEFAULT_CONF_FILENAME) + 1;
+            char *path = static_cast<char *>(::malloc(len));
+            if (!path) return nullptr;
+            snprintf(path, len, "%s/%s", xdg_config_home, DEFAULT_CONF_FILENAME);
+
+            if (access(path, F_OK) == 0) {
+                return path; // file exists
+            }
+
+            free(path);
+            path = nullptr;
         }
-        return std::format("{}/.config/{}", getenv("HOME"), config_file_name);
+
+        if (home != nullptr) {
+            size_t len = strlen(home) + strlen("/.config/") + strlen(DEFAULT_CONF_FILENAME) + 1;
+            char *path = static_cast<char *>(::malloc(len));
+            if (!path) return nullptr;
+            snprintf(path, len, "%s/.config/%s", home, DEFAULT_CONF_FILENAME);
+
+            if (access(path, F_OK) == 0) {
+                return path; // file exists
+            }
+
+            free(path);
+            path = nullptr;
+        }
+
+        // If neither env var is set, fallback to just filename in current dir
+        return strdup(DEFAULT_CONF_FILENAME);
     }
 
     // =============================================================================
@@ -643,7 +676,7 @@ namespace bongocat {
         printf("Options:\n");
         printf("  -h, --help                  Show this help message\n");
         printf("  -v, --version               Show version information\n");
-        printf("  -c, --config                Specify config file (default: bongocat.conf)\n");
+        printf("  -c, --config                Specify config file (default: ~/.config/bongocat.conf)\n");
         printf("  -w, --watch-config          Watch config file for changes and reload automatically\n");
         printf("  -t, --toggle                Toggle bongocat on/off (start if not running, stop if running)\n");
         printf("  -o, --output-name NAME      Specify output name (overwrite output_name from config)\n");
@@ -776,10 +809,18 @@ int main(int argc, char *argv[]) {
         .randomize_index = args.randomize_index,
         .strict = args.strict,
     };
+    if (args.config_file == nullptr) {
+        get_main_context().default_config_filename = default_config_file_path();
+    }
+    const char* config_file = args.config_file == nullptr ? get_main_context().default_config_filename : args.config_file;
+    if (args.strict) {
+        if (strcmp(config_file, "-") != 0 && access(config_file, F_OK) != 0) {
+            BONGOCAT_LOG_ERROR("Configuration file required: %s", config_file);
+            return EXIT_FAILURE;
+        }
+    }
 
-    const auto config_file = args.config_file == nullptr ? default_config_file_path() : std::string{args.config_file};
-
-    auto [config, config_error] = config::load(config_file.c_str(), ctx.overwrite_config_parameters);
+    auto [config, config_error] = config::load(config_file, ctx.overwrite_config_parameters);
     if (config_error != bongocat_error_t::BONGOCAT_SUCCESS) {
         BONGOCAT_LOG_ERROR("Failed to load configuration: %s", bongocat::error_string(config_error));
         return EXIT_FAILURE;
@@ -865,7 +906,7 @@ int main(int argc, char *argv[]) {
     BONGOCAT_LOG_INFO("bongocat PID: %d", pid);
 
     // Setup signal handlers
-    ctx.signal_watch_path = config_file.c_str();
+    ctx.signal_watch_path = config_file;
     bongocat_error_t signal_result = signal_setup_handlers(ctx);
     if (signal_result != bongocat_error_t::BONGOCAT_SUCCESS) {
         BONGOCAT_LOG_ERROR("Failed to setup signal handlers: %s", bongocat::error_string(signal_result));
@@ -875,8 +916,8 @@ int main(int argc, char *argv[]) {
     
     // Initialize config watcher if requested
     if (args.watch_config) {
-        if (config_file != "-") {
-            start_config_watcher(ctx, config_file.c_str());
+        if (strcmp(config_file, "-") == 0) {
+            start_config_watcher(ctx, config_file);
         } else {
             BONGOCAT_LOG_INFO("Skip config watcher, no config watcher fir stdin");
         }


### PR DESCRIPTION
It's a bit unfortunate that the executable segfaults if being run without the required config parameter.

This is an attempt at fixing that. The first commit simply fixes the segfault so a user friendly error message is provided instead, while the second also makes use of either the config file in the default or location or the already existing default configuration if no configuration file is found.